### PR TITLE
Add input to generate netlist in XML format

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,6 +167,7 @@ jobs:
             "bom",
             "bom-custom",
             "netlist",
+            "netlist-xml",
           ]
         include:
           - test_name: pdf
@@ -211,6 +212,9 @@ jobs:
           - test_name: netlist
             output_flag: schematic_output_netlist
             expected_file: netlist.net
+          - test_name: netlist-xml
+            output_flag: schematic_output_xml_netlist
+            expected_file: netlist.xml
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -211,6 +211,21 @@ Default: `netlist.net`\
 \
 Description: Output file name of the netlist.
 
+## `schematic_output_xml_netlist`
+
+Required: `false`\
+Default: `false`\
+\
+Description: Run the netlist export of the schematic, in XML format for further
+processing.
+
+## `schematic_output_xml_netlist_file_name`
+
+Required: `false`\
+Default: `netlist.xml`\
+\
+Description: Output file name of the XML netlist.
+
 ## `pcb_file_name`
 
 Required: `false`\

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,15 @@ inputs:
     description: "Output file name of the netlist."
     default: "netlist.net"
 
+  # Schematic netlist output (XML format)
+  schematic_output_xml_netlist:
+    description: "Run the XML netlist export of the schematic."
+    default: false
+
+  schematic_output_xml_netlist_file_name:
+    description: "Output file name of the XML netlist."
+    default: "netlist.xml"
+
   # PCB input file
   pcb_file_name:
     description: "Location of the '.kicad_pcb' file."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -194,6 +194,14 @@ if [[ -n $INPUT_SCHEMATIC_FILE_NAME ]]; then
       --output "$INPUT_SCHEMATIC_OUTPUT_NETLIST_FILE_NAME" \
       "$INPUT_SCHEMATIC_FILE_NAME"
   fi
+
+  # Export schematic XML netlist
+  if [[ $INPUT_SCHEMATIC_OUTPUT_XML_NETLIST == "true" ]]; then
+    kicad-cli sch export netlist \
+      --format kicadxml \
+      --output "$INPUT_SCHEMATIC_OUTPUT_XML_NETLIST_FILE_NAME" \
+      "$INPUT_SCHEMATIC_FILE_NAME"
+  fi
 fi
 
 # Run PCB outputs


### PR DESCRIPTION
This format is useful for further processing, e.g. grouping of line items using an XSLT transform.