### PR TITLE
Support running a jobset

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -448,3 +448,47 @@ jobs:
           path: ./pcb.png
           archive: false
           if-no-files-found: error
+
+  test-jobset:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Run jobset
+        uses: ./
+        with:
+          symbol_libraries: "test-sym-library=tests/kicad-project-success/test-sym-library.kicad_sym"
+          jobset_file_name: tests/kicad-project-success/kicad-project.kicad_jobset
+          project_file_name: tests/kicad-project-success/kicad-project.kicad_pro
+
+      - name: Verify output file
+        run: |
+          if [[ ! -f jobset_out/erc.rpt ]]; then
+            echo "::error::Expected output file 'jobset_out/erc.rpt' not found!"
+            exit 1
+          fi
+        shell: bash
+
+  test-jobset-detect-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Move project files to CWD
+        run: mv tests/kicad-project-success/* .
+
+      - name: Run jobset (detect project file)
+        uses: ./
+        with:
+          symbol_libraries: "test-sym-library=test-sym-library.kicad_sym"
+          jobset_file_name: kicad-project.kicad_jobset
+
+      - name: Verify output file
+        run: |
+          if [[ ! -f jobset_out/erc.rpt ]]; then
+            echo "::error::Expected output file 'jobset_out/erc.rpt' not found!"
+            exit 1
+          fi
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ steps:
 
 # 📥 Inputs
 
+## `project_file_name`
+
+Required: `false`\
+\
+Description: The project file, used for running a jobset. Not required if there
+is a single `.kicad_pro` file in the working directory.
+
 ## `schematic_file_name`
 
 Required: `false`\
@@ -511,6 +518,12 @@ Required: `false`\
 Default: `0,0,0`\
 \
 Description: "Rotation of the image PCB. Format: 'x,y,z'."
+
+## `jobset_file_name`
+
+Required: `false`\
+\
+Description: Run a predefined KiCad jobset file.
 
 # 📤 Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ branding:
   color: "green"
 
 inputs:
+  # Project file
+  project_file_name:
+    description: "The project file, used for running a jobset. Not required if there is a single `.kicad_pro` file in the working directory."
+
   # Schematic input file
   schematic_file_name:
     description: "Location of the '.kicad_sch' file."
@@ -256,6 +260,10 @@ inputs:
   pcb_output_image_rotate:
     description: "Rotation of the image PCB. Format: 'x,y,z'."
     default: "0,0,0"
+
+  # Jobset
+  jobset_file_name:
+    description: "Run a predefined KiCad jobset file."
 
 runs:
   using: "docker"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,6 +81,34 @@ $entry
   fi
 }
 
+find_project_file() {
+  if [[ -n "$INPUT_PROJECT_FILE_NAME" ]]; then
+    if [ ! -f "$INPUT_PROJECT_FILE_NAME" ]; then
+      echo "::error::Project file '$INPUT_PROJECT_FILE_NAME' not found."
+      exit 1
+    fi
+    project_file_name="$INPUT_PROJECT_FILE_NAME"
+  else
+    # Find project file in working directory
+    shopt -s nullglob
+    local candidates=( *.kicad_pro )
+    shopt -u nullglob
+    case "${#candidates[@]}" in
+      0)
+        echo "::error::project_file_name not specified, and no .kicad_pro file found."
+        exit 1
+        ;;
+      1)
+        project_file_name="${candidates[0]}"
+        ;;
+      *)
+        echo "::error::project_file_name not specified, and multiple .kicad_pro files found."
+        exit 1
+        ;;
+    esac
+  fi
+}
+
 # Check if any schematic output/erc are selected without the file being present
 if [[ -z $INPUT_SCHEMATIC_FILE_NAME && (
     $INPUT_RUN_ERC == "true" || 
@@ -403,6 +431,18 @@ if [[ -n $INPUT_PCB_FILE_NAME ]]; then
     [[ $INPUT_PCB_OUTPUT_IMAGE_FLOOR == "true" ]] && cmd+=(--floor)
     "${cmd[@]}" "$INPUT_PCB_FILE_NAME"
   fi
+fi
+
+# Run jobset
+if [[ -n $INPUT_JOBSET_FILE_NAME ]]; then
+  # Confirm that the file exists
+  if [ ! -f "$INPUT_JOBSET_FILE_NAME" ]; then
+    echo "::error::Jobset file '$INPUT_JOBSET_FILE_NAME' not found."
+    exit 1
+  fi
+
+  find_project_file
+  kicad-cli jobset run --file "$INPUT_JOBSET_FILE_NAME" "$project_file_name"
 fi
 
 # Return non-zero exit code for ERC or DRC violations

--- a/tests/kicad-project-success/kicad-project.kicad_jobset
+++ b/tests/kicad-project-success/kicad-project.kicad_jobset
@@ -1,0 +1,31 @@
+{
+  "jobs": [
+    {
+      "description": "Schematic ERC",
+      "id": "0fcb537f-8eb9-4379-af27-a66094430c9b",
+      "settings": {
+        "description": "Schematic ERC",
+        "fail_on_error": false,
+        "format": "report",
+        "output_filename": "erc.rpt",
+        "severity": 48,
+        "units": "mm"
+      },
+      "type": "sch_erc"
+    }
+  ],
+  "meta": {
+    "version": 1
+  },
+  "outputs": [
+    {
+      "description": "Jobset outputs",
+      "id": "298c510b-a4ce-4135-8bb0-8639680d1767",
+      "only": [],
+      "settings": {
+        "output_path": "jobset_out"
+      },
+      "type": "folder"
+    }
+  ]
+}


### PR DESCRIPTION
This allows a jobset to be run, by specifying the filename.

The project file also needs to be passed to `kicad-cli`, so I've added an input to specify that. If the project file is not specified, but (exactly) one exists in the root directory, that is used automatically.