### PR TITLE
fix: increase query delay and run workflow weekly to avoid rate limits

### DIFF
--- a/.github/workflows/count-action-users.yml
+++ b/.github/workflows/count-action-users.yml
@@ -2,7 +2,7 @@ name: Count action users
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 0"
   workflow_dispatch:
 
 jobs:
@@ -19,5 +19,6 @@ jobs:
         with:
           target-directory: docs
           action-list: actions-for-kicad/kicad-actions
+          query-delay: 200
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
- Increase query-delay from default to 200ms to throttle API requests
- Change cron schedule from daily (0 0 * * *) to weekly on Sunday (0 0 * * 0)
- Reduces API rate limit errors from GitHub API queries